### PR TITLE
FIXED build process error on get_or_insert_default()

### DIFF
--- a/crates/uk-manager/src/bnp/shops.rs
+++ b/crates/uk-manager/src/bnp/shops.rs
@@ -44,8 +44,7 @@ fn merge(data: &mut ShopData, diff: &ParameterList) -> Result<()> {
         .iter_by_name()
     {
         let name: String64 = name.expect("Bad shop diff").as_ref().into();
-        #[allow(unstable_name_collisions)]
-        let base = data.0.entry(name).or_default().get_or_insert_default();
+        let base = data.0.entry(name).or_default().get_or_insert_with(Default::default);
         for (i, (name, params)) in table.objects.iter_by_name().enumerate() {
             let name: String64 = name
                 .ok()

--- a/src/gui/settings.rs
+++ b/src/gui/settings.rs
@@ -305,7 +305,7 @@ fn render_deploy_config(config: &mut DeployConfig, platform: Platform, ui: &mut 
             ui,
             |ui| {
                 changed |= ui
-                    .file_picker_string(config.executable.get_or_insert_default())
+                    .file_picker_string(config.executable.get_or_insert_with(Default::default))
                     .changed();
             },
         );
@@ -410,7 +410,7 @@ fn render_platform_config(
                     ui,
                     |ui| {
                         if ui
-                            .folder_picker(content_dir.get_or_insert_default())
+                            .folder_picker(content_dir.get_or_insert_with(Default::default))
                             .changed()
                         {
                             changed = true;
@@ -427,7 +427,7 @@ fn render_platform_config(
                         ui,
                         |ui| {
                             if ui
-                                .folder_picker(update_dir.get_or_insert_default())
+                                .folder_picker(update_dir.get_or_insert_with(Default::default))
                                 .changed()
                             {
                                 changed = true;
@@ -446,7 +446,7 @@ fn render_platform_config(
                     &description,
                     ui,
                     |ui| {
-                        if ui.folder_picker(aoc_dir.get_or_insert_default()).changed() {
+                        if ui.folder_picker(aoc_dir.get_or_insert_with(Default::default)).changed() {
                             changed = true;
                             *host_path = "/".into();
                         }

--- a/src/gui/tasks.rs
+++ b/src/gui/tasks.rs
@@ -515,7 +515,7 @@ pub fn import_cemu_settings(core: &Manager, path: &Path) -> Result<Message> {
     };
     if let Some(wiiu_config) = settings.wiiu_config.as_mut() {
         wiiu_config.dump = dump;
-        let deploy_config = wiiu_config.deploy_config.get_or_insert_default();
+        let deploy_config = wiiu_config.deploy_config.get_or_insert_with(Default::default);
         deploy_config.auto = true;
         deploy_config.cemu_rules = true;
         deploy_config.output = gfx_folder.clone();


### PR DESCRIPTION
OS: Ubuntu 24.04.2 LTS
Kernel: 6.14.0-27-generic

Error while compiling:

```
error[E0658]: use of unstable library feature 'option_get_or_insert_default'
  --> crates/uk-manager/src/bnp/shops.rs:48:52
   |
48 |         let base = data.0.entry(name).or_default().get_or_insert_default();
   |                                                    ^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #82901 <https://github.com/rust-lang/rust/issues/82901> for more information

For more information about this error, try `rustc --explain E0658`.
error: could not compile `uk-manager` (lib) due to 1 previous error
warning: build failed, waiting for other jobs to finish...
```

Fixed by adding more stable syntax for the compilator