### PR TITLE
Pending files patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@ be obvious from the Info tab.
 - Reordered bnp map conversions, so modifications apply to the right map instances
 - Made sure DeleteSets actually deleted the things marked for deletion. Whoops!
   Fixes various merge errors in BoneControl, ActorLink, and other files
+- Fixed various deployment errors, reimplemented partial deployment
 
 ## [0.16.0] - 2025-01-27
 

--- a/crates/uk-manager/src/deploy.rs
+++ b/crates/uk-manager/src/deploy.rs
@@ -72,11 +72,7 @@ impl Manager {
                 log
             }
             Err(_) => {
-                let old_pending = match fs::read_to_string(
-                    &Self::log_path(&settings.read())
-                )
-                    .map_err(anyhow_ext::Error::from)
-                    .and_then(|text| Ok(serde_yaml::from_str::<OldPendingLog>(&text)?))
+                let old_pending = match serde_yaml::from_str::<OldPendingLog>(&pending_text)
                 {
                     Ok(old_log) => {
                         if !old_log.files.is_empty() || !old_log.delete.is_empty() {

--- a/crates/uk-manager/src/deploy/file.rs
+++ b/crates/uk-manager/src/deploy/file.rs
@@ -1,0 +1,118 @@
+use std::path::PathBuf;
+use anyhow::anyhow;
+use anyhow_ext::{Context, Result};
+use serde::{Deserialize, Serialize};
+use serde_with::serde_as;
+use smartstring::alias::String;
+
+#[serde_as]
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct File {
+    name: String,
+}
+
+impl From<String> for File {
+    fn from(name: String) -> Self {
+        Self { name }
+    }
+}
+
+impl TryFrom<&PathBuf> for File {
+    type Error = anyhow_ext::Error;
+
+    fn try_from(path: &PathBuf) -> Result<Self> {
+        if !path.exists() || path.is_dir() {
+            Err(anyhow!("{:?} is not a valid file", path))
+        }
+        else {
+            Ok(Self {
+                name: path.file_name()
+                    .ok_or(anyhow!("File name is empty"))?
+                    .to_string_lossy()
+                    .into()
+            })
+        }
+    }
+}
+
+impl File {
+    #[inline(always)]
+    pub fn name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    pub fn should_move(&self, from: &PathBuf, to: &PathBuf) -> Result<bool> {
+        let old = from.join(self.name.as_str());
+        let new = to.join(self.name.as_str());
+        if !old.exists() {
+            Ok(false)
+        }
+        else if !new.exists() {
+            Ok(true)
+        }
+        else if old.metadata()?.modified()? != new.metadata()?.modified()? {
+            Ok(true)
+        }
+        //else if old.metadata()?.created()? > new.metadata()?.created()? {
+        //    Ok(true)
+        //}
+        else {
+            Ok(false)
+        }
+    }
+
+    #[inline(always)]
+    pub fn should_delete(&self, from: &PathBuf, based_on: &PathBuf) -> Result<bool> {
+        Ok(from.join(self.name.as_str()).exists() && !based_on.join(self.name.as_str()).exists())
+    }
+
+    pub fn copy(&self, from: &PathBuf, to: &PathBuf) -> Result<()> {
+        let old = from.join(self.name.as_str());
+        let new = to.join(self.name.as_str());
+        if old.exists() {
+            std::fs::copy(&old, &new)
+                .with_context(|| format!("Failed to deploy {} to {}", self.name, &new.display()))?;
+            std::fs::File::options()
+                .write(true)
+                .open(new)?
+                .set_modified(std::fs::metadata(old)?.modified()?)?;
+        } else {
+            log::warn!(
+                "Source file {} missing, we're assuming it was a deletion lost track of",
+                old.display()
+            );
+            if new.exists() {
+                std::fs::remove_file(&new)?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn hard_link(&self, from: &PathBuf, to: &PathBuf) -> Result<()> {
+        let old = from.join(self.name.as_str());
+        let new = to.join(self.name.as_str());
+        if new.exists() {
+            std::fs::remove_file(&new)?;
+        }
+        if old.exists() {
+            std::fs::hard_link(old, &new)
+                .with_context(|| format!("Failed to deploy {} to {}", self.name, &new.display()))
+                .map_err(|e| {
+                    if e.root_cause().to_string().contains("os error 17") {
+                        e.context(
+                            "Hard linking failed because the output folder is on a \
+                             different disk or partition than the storage folder.",
+                        )
+                    } else {
+                        e
+                    }
+                })?;
+        } else {
+            log::warn!(
+                "Source file {} missing, we're assuming it was a deletion lost track of",
+                old.display()
+            );
+        }
+        Ok(())
+    }
+}

--- a/crates/uk-manager/src/deploy/folder.rs
+++ b/crates/uk-manager/src/deploy/folder.rs
@@ -1,0 +1,231 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::path::PathBuf;
+use anyhow::anyhow;
+use anyhow_ext::{Result, Error, Context};
+use rayon::prelude::*;
+use smartstring::alias::String;
+use serde::{Deserialize, Serialize};
+use crate::deploy::file::File;
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub struct Folder {
+    folders: BTreeMap<String, Folder>,
+    files: BTreeSet<File>,
+}
+
+impl TryFrom<&PathBuf> for Folder {
+    type Error = Error;
+
+    fn try_from(path: &PathBuf) -> Result<Self> {
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        if path.is_file() {
+            Err(anyhow!("{:?} is not a valid folder", path))
+        }
+        else {
+            let mut folders: BTreeMap<String, Folder> = BTreeMap::new();
+            let mut files: BTreeSet<File> = BTreeSet::new();
+            for entry in path.as_path().read_dir()? {
+                let p = &entry?.path();
+                if p.is_dir() {
+                    folders.insert(
+                        p.file_name()
+                            .ok_or(anyhow!("{} has no file name?", p.display()))?
+                            .to_string_lossy()
+                            .into(),
+                        p.try_into()?
+                    );
+                }
+                else {
+                    files.insert(p.try_into()?);
+                }
+            }
+            Ok(Self { folders, files })
+        }
+    }
+}
+
+impl Folder {
+    #[inline(always)]
+    pub fn has_some(&self) -> bool {
+        !self.files.is_empty() || !self.folders.is_empty()
+    }
+
+    #[inline(always)]
+    pub fn contains_folder(&self, name: &str) -> bool {
+        self.folders.contains_key(name)
+    }
+
+    #[inline(always)]
+    pub fn insert_folder(&mut self, name: String) {
+        self.folders.insert(name, Folder::default());
+    }
+
+    #[inline(always)]
+    pub fn get_folder_mut(&mut self, name: &str) -> Option<&mut Folder> {
+        self.folders.get_mut(name)
+    }
+
+    pub fn extend(&mut self, other: BTreeSet<String>) -> Result<()> {
+        for path in other.into_iter() {
+            self.extend_iter(PathBuf::from(path.as_str()).iter())?;
+        }
+        Ok(())
+    }
+
+    pub fn extend_iter(&mut self, mut iter: std::path::Iter) -> Result<()> {
+        let name: String = iter.next()
+            .ok_or_else(|| anyhow!("{:?} is empty?", iter))?
+            .to_string_lossy()
+            .into();
+        if name.contains('.') {
+            self.files.insert(name.into());
+        }
+        else {
+            if !self.folders.contains_key(&name) {
+                self.folders.insert(name.clone(), Folder::default());
+            }
+            self.folders.get_mut(&name)
+                .unwrap_or_else(|| unsafe { std::hint::unreachable_unchecked() })
+                .extend_iter(iter)?;
+        }
+        Ok(())
+    }
+
+    pub fn compile_moves(from: &PathBuf, to: &PathBuf) -> Result<Self> {
+        let mut folders: BTreeMap<String, Folder> = BTreeMap::new();
+        let mut files: BTreeSet<File> = BTreeSet::new();
+        if from.exists() {
+            from.read_dir()?.try_for_each(|f| -> Result<()> {
+                let from_path = f?.path();
+                if from_path.is_file() {
+                    let file: File = (&from_path).try_into().context("Could not create File")?;
+                    if file.should_move(from, to)
+                        .with_context(|| format!(
+                            "Failed to determine if {:?} should move from {:?} to {:?}",
+                            file.name(),
+                            from,
+                            to
+                        ))? {
+                        files.insert(file);
+                    }
+                }
+                else if from_path.is_dir() {
+                    let folder_name = from_path.file_name()
+                        .context("Folder should have name")?;
+                    let to_path = to.join(&folder_name);
+                    let folder: Folder = Self::compile_moves(&from_path, &to_path)
+                        .with_context(|| format!(
+                            "Failed to compile moves from {:?} to {:?}",
+                            from_path,
+                            to_path
+                        ))?;
+                    if folder.has_some() {
+                        folders.insert(folder_name.to_string_lossy().into(), folder);
+                    }
+                }
+                Ok(())
+            })?;
+        }
+        Ok(Self { folders, files })
+    }
+
+    pub fn compile_deletes(from: &PathBuf, based_on: &PathBuf) -> Result<Self> {
+        let mut folders: BTreeMap<String, Folder> = BTreeMap::new();
+        let mut files: BTreeSet<File> = BTreeSet::new();
+        if from.exists() {
+            from.read_dir()?.try_for_each(|f| -> Result<()> {
+                let from_path = f?.path();
+                if from_path.is_file() {
+                    let file: File = (&from_path).try_into().context("Could not create File")?;
+                    if file.should_delete(from, based_on)
+                        .with_context(|| format!(
+                            "Failed to determine if {:?} should be deleted from {:?} based on {:?}",
+                            file.name(),
+                            from,
+                            based_on
+                        ))? {
+                        files.insert(file);
+                    }
+                }
+                else if from_path.is_dir() {
+                    let folder_name = from_path.file_name()
+                        .context("Folder should have name")?;
+                    let based_on_path = based_on.join(&folder_name);
+                    let folder: Folder = Self::compile_deletes(&from_path, &based_on_path)
+                        .with_context(|| format!(
+                            "Failed to compile deletes from {:?} based on {:?}",
+                            from_path,
+                            based_on_path
+                        ))?;
+                    if folder.has_some() {
+                        folders.insert(folder_name.to_string_lossy().into(), folder);
+                    }
+                }
+                Ok(())
+            })?;
+        }
+        Ok(Self { folders, files })
+    }
+
+    pub fn copy(&self, from: &PathBuf, to: &PathBuf) -> Result<()> {
+        self.files.par_iter().try_for_each(|file| -> Result<()> {
+            file.copy(from, to)
+        })?;
+        self.folders.par_iter().try_for_each(|(folder_name, folder)| -> Result<()> {
+            let new_path = to.join(folder_name.as_str());
+            if !new_path.exists() {
+                std::fs::create_dir(&new_path)?;
+            }
+            folder.copy(&from.join(folder_name.as_str()), &new_path)
+        })?;
+        Ok(())
+    }
+
+    pub fn hard_link(&self, from: &PathBuf, to: &PathBuf) -> Result<()> {
+        self.files.par_iter().try_for_each(|file| -> Result<()> {
+            file.hard_link(from, to)
+        })?;
+        self.folders.par_iter().try_for_each(|(folder_name, folder)| -> Result<()> {
+            let new_path = to.join(folder_name.as_str());
+            if !new_path.exists() {
+                std::fs::create_dir(&new_path)?;
+            }
+            folder.hard_link(&from.join(folder_name.as_str()), &new_path)
+        })?;
+        Ok(())
+    }
+
+    pub fn delete(&self, path: &PathBuf) -> Result<()> {
+        self.files.par_iter().try_for_each(|file| -> Result<()> {
+            let file_path = path.join(file.name());
+            if file_path.exists() {
+                std::fs::remove_file(&file_path)
+                    .with_context(|| format!("Failed to delete file {:?}", file_path))?;
+            }
+            else {
+                log::warn!("File {:?} was not found", file_path);
+            }
+            Ok(())
+        })?;
+        self.folders.par_iter().try_for_each(|(folder_name, folder)| -> Result<()> {
+            let folder_path = path.join(folder_name.as_str());
+            if folder_path.exists() {
+                folder.delete(&folder_path)?;
+                if folder_path.read_dir()?.next().is_none() {
+                    std::fs::remove_dir(&folder_path)
+                        .with_context(||
+                            format!("Failed to remove empty folder: {}", folder_path.display())
+                        )?;
+                }
+            }
+            Ok(())
+        })?;
+        Ok(())
+    }
+
+    pub fn len(&self) -> usize {
+        self.files.len() + self.folders.par_iter().map(|(_, v)| v.len()).sum::<usize>()
+    }
+}

--- a/crates/uk-manager/src/deploy/pending_log.rs
+++ b/crates/uk-manager/src/deploy/pending_log.rs
@@ -1,0 +1,104 @@
+use std::collections::BTreeSet;
+use std::path::PathBuf;
+use anyhow::anyhow;
+use anyhow_ext::{Result, Error, Context};
+use serde::{Deserialize, Serialize};
+use smartstring::alias::String;
+use uk_mod::Manifest;
+use crate::deploy::folder::Folder;
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct PendingLog {
+    pub(crate) content_copies: Folder,
+    pub(crate) aoc_copies: Folder,
+    pub(crate) content_deletes: Folder,
+    pub(crate) aoc_deletes: Folder,
+}
+
+impl TryFrom<crate::deploy::OldPendingLog> for PendingLog {
+    type Error = Error;
+    fn try_from(pending: crate::deploy::OldPendingLog) -> Result<Self> {
+        fn convert_set(files: BTreeSet<String>) -> Result<Folder> {
+            let mut map: Folder = Default::default();
+            for f in files {
+                let path = PathBuf::from(f.as_str());
+                let mut iter = path.iter();
+                let name: String = iter.next()
+                    .ok_or(anyhow!("{} is empty?", f))?
+                    .to_string_lossy()
+                    .into();
+                if !name.contains('.') {
+                    if !map.contains_folder(&name) {
+                        map.insert_folder(name.clone());
+                    }
+                    map.get_folder_mut(&name).expect("Can't happen").extend_iter(iter)?;
+                }
+            }
+            Ok(map)
+        }
+
+        Ok(Self {
+            content_copies: convert_set(pending.files.content_files)?,
+            aoc_copies: convert_set(pending.files.aoc_files)?,
+            content_deletes: convert_set(pending.delete.content_files)?,
+            aoc_deletes: convert_set(pending.delete.aoc_files)?,
+        })
+    }
+}
+
+impl TryFrom<(PathBuf, PathBuf, PathBuf, PathBuf)> for PendingLog {
+    type Error = Error;
+
+    fn try_from(value: (PathBuf, PathBuf, PathBuf, PathBuf)) -> Result<Self> {
+        let (source_content, source_aoc, dest_content, dest_aoc) = value;
+        Ok(PendingLog {
+            content_copies: Folder::compile_moves(&source_content, &dest_content)
+                .context("Failed to compile pending content moves")?,
+            aoc_copies: Folder::compile_moves(&source_aoc, &dest_aoc)
+                .context("Failed to compile pending aoc moves")?,
+            content_deletes: Folder::compile_deletes(&dest_content, &source_content)
+                .context("Failed to compile pending content deletes")?,
+            aoc_deletes: Folder::compile_deletes(&dest_aoc, &source_aoc)
+                .context("Failed to compile pending aoc deletes")?,
+        })
+    }
+}
+
+impl PendingLog {
+    pub fn extend_copies(&mut self, other: &Manifest) -> Result<()> {
+        self.content_copies.extend(other.content_files.clone())?;
+        self.aoc_copies.extend(other.aoc_files.clone())?;
+        Ok(())
+    }
+
+    pub fn extend_deletes(&mut self, other: &Manifest) -> Result<()> {
+        self.content_deletes.extend(other.content_files.clone())?;
+        self.aoc_deletes.extend(other.aoc_files.clone())?;
+        Ok(())
+    }
+
+    #[inline(always)]
+    pub fn has_some(&self) -> bool {
+        self.content_copies.has_some() || self.aoc_copies.has_some() ||
+            self.content_deletes.has_some() || self.aoc_deletes.has_some()
+    }
+
+    #[inline(always)]
+    pub fn len(&self) -> usize {
+        self.content_copies.len() + self.aoc_copies.len() +
+            self.content_deletes.len() + self.aoc_deletes.len()
+    }
+
+    pub fn clear(&mut self) {
+        self.content_copies = Default::default();
+        self.aoc_copies = Default::default();
+        self.content_deletes = Default::default();
+        self.aoc_deletes = Default::default();
+    }
+
+    pub fn add_rstb(&mut self) -> Result<()> {
+        self.content_copies.extend_iter(
+            PathBuf::from("System/Resource/ResourceSizeTable.product.srsizetable").iter()
+        )
+    }
+}

--- a/src/gui/update.rs
+++ b/src/gui/update.rs
@@ -469,6 +469,7 @@ impl App {
                     self.do_task(|core| {
                         log::info!("Resetting pending deployment data");
                         core.deploy_manager().reset_pending()?;
+                        core.deploy_manager().save()?;
                         Ok(Message::Noop)
                     })
                 }


### PR DESCRIPTION
Replaces the existing pending logs with a (rather over-engineered, perhaps) system for ensuring that copy and hard link deploy modes have their deployments match the merge folder after deployment.

Fixes partial deployment (removed some time ago), correctly deleting empty folders from the deploy area when possible (essentially, when deployment itself removes all files in a folder), and correctly determining what files/folders need to be deployed (and ensuring the correct code functions are used for each).