### PR TITLE
Byml parse fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ be obvious from the Info tab.
 - Reordered bnp map conversions, so modifications apply to the right map instances
 - Made sure DeleteSets actually deleted the things marked for deletion. Whoops!
   Fixes various merge errors in BoneControl, ActorLink, and other files
+- Fixes a rare error where some files with no header in their format would be
+  recognized as byml files instead of binary
 
 ## [0.16.0] - 2025-01-27
 

--- a/crates/uk-content/src/resource.rs
+++ b/crates/uk-content/src/resource.rs
@@ -614,7 +614,8 @@ impl MergeableResource {
             Ok(Some(Self::GenericAamp(Box::new(
                 ParameterIO::from_binary(data)?,
             ))))
-        } else if data.len() > 2 && matches!(&data[..2], b"BY" | b"YB") {
+        } else if data.len() > 4 && matches!(&data[..2], b"BY" | b"YB") &&
+            (as_u16_be(&data[2..4]) < 8 || as_u16_le(&data[2..4]) < 8) {
             Ok(Some(Self::GenericByml(Box::new(Byml::from_binary(data)?))))
         } else {
             Ok(None)
@@ -690,6 +691,16 @@ impl MergeableResource {
             }
         }
     }
+}
+
+fn as_u16_be(array: &[u8; 2]) -> u16 {
+    ((array[2] as u16) <<  8) +
+    ((array[3] as u16) <<  0)
+}
+
+fn as_u16_le(array: &[u8; 2]) -> u16 {
+    ((array[0] as u16) <<  0) +
+    ((array[1] as u16) <<  8)
 }
 
 pub trait ResourceRegister {

--- a/crates/uk-content/src/resource.rs
+++ b/crates/uk-content/src/resource.rs
@@ -693,12 +693,12 @@ impl MergeableResource {
     }
 }
 
-fn as_u16_be(array: &[u8; 2]) -> u16 {
-    ((array[2] as u16) <<  8) +
-    ((array[3] as u16) <<  0)
+fn as_u16_be(array: &[u8]) -> u16 {
+    ((array[1] as u16) <<  0) +
+    ((array[0] as u16) <<  8)
 }
 
-fn as_u16_le(array: &[u8; 2]) -> u16 {
+fn as_u16_le(array: &[u8]) -> u16 {
     ((array[0] as u16) <<  0) +
     ((array[1] as u16) <<  8)
 }


### PR DESCRIPTION
Fixes a rare error where some files with no header in their format would be recognized as byml files instead of binary

There is still the rare case where a binary file may start with things like b'BY\u0007' but a 4 byte match is significantly less likely than a 2 byte match, so hopefully this is sufficient to cover modders' use cases