### PR TITLE
Fix egui assertion failures in debug mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ be obvious from the Info tab.
   Fixes various merge errors in BoneControl, ActorLink, and other files
 - Fixes a rare error where some files with no header in their format would be
   recognized as byml files instead of binary
+- Fixed egui assertion failures in debug mode caused by invalid widget sizes
+  (NaN or negative values). All size values passed to egui are now validated
+  to ensure they are finite and non-negative
 
 ## [0.16.0] - 2025-01-27
 

--- a/src/gui/info.rs
+++ b/src/gui/info.rs
@@ -72,7 +72,8 @@ impl Component for ModInfo<'_> {
             ui.spacing_mut().item_spacing.y = 8.;
             ui.add_space(8.);
             if let Some(preview) = self.preview() {
-                preview.show_max_size(ui, ui.available_size());
+                let available = ui.available_size();
+                preview.show_max_size(ui, [available.x.max(0.0), available.y.max(0.0)].into());
                 ui.add_space(8.);
             }
             let ver = mod_.meta.version.to_string();

--- a/src/gui/modals.rs
+++ b/src/gui/modals.rs
@@ -260,11 +260,11 @@ impl App {
                 .frame(Frame::window(&ctx.style()).inner_margin(8.))
                 .show(ctx, |ui| {
                     let max_width =
-                        (ui.available_width() / 2.).min(ctx.screen_rect().size().x - 64.0);
+                        (ui.available_width() / 2.).min(ctx.screen_rect().size().x - 64.0).max(0.0);
                     ui.vertical_centered(|ui| {
                         let text_height = ui.text_style_height(&TextStyle::Body) * 2.;
-                        let padding = 80. - text_height - 8.;
-                        ui.allocate_space([max_width, padding / 2.].into());
+                        let padding = (80. - text_height - 8.).max(0.0);
+                        ui.allocate_space([max_width, (padding / 2.).max(0.0)].into());
                         ui.horizontal(|ui| {
                             ui.add_space(8.);
                             ui.add(Spinner::new().size(text_height));
@@ -280,7 +280,7 @@ impl App {
                             });
                             ui.shrink_width_to_current();
                         });
-                        ui.allocate_space([0., padding / 2.].into());
+                        ui.allocate_space([0., (padding / 2.).max(0.0)].into());
                     });
                 });
         }

--- a/src/gui/picker.rs
+++ b/src/gui/picker.rs
@@ -375,7 +375,8 @@ impl App {
                     entries.clone().iter().for_each(|path| {
                         self.render_picker_dir_entry(path, ui);
                     });
-                    ui.allocate_space(ui.available_size());
+                    let available = ui.available_size();
+                    ui.allocate_space([available.x.max(0.0), available.y.max(0.0)].into());
                 });
         });
     }

--- a/src/gui/profiles.rs
+++ b/src/gui/profiles.rs
@@ -95,7 +95,8 @@ impl ProfileManagerState {
                                     ui.label(loc.get("Profile_NoMods"));
                                 });
                             }
-                            ui.allocate_space(ui.available_size());
+                            let available = ui.available_size();
+                            ui.allocate_space([available.x.max(0.0), available.y.max(0.0)].into());
                         });
                     ui.add_space(8.0);
                     if let Some(new_name) = self.rename.as_mut() {
@@ -135,7 +136,8 @@ impl ProfileManagerState {
                 });
             });
             ui.end_row();
-            ui.allocate_space(ui.available_size());
+            let available = ui.available_size();
+            ui.allocate_space([available.x.max(0.0), available.y.max(0.0)].into());
         }
     }
 
@@ -182,7 +184,8 @@ impl ProfileManagerState {
                                         }
                                     });
                                 });
-                                ui.allocate_space(ui.available_size());
+                                let available = ui.available_size();
+                            ui.allocate_space([available.x.max(0.0), available.y.max(0.0)].into());
                             });
                             self.render_selected_profile(app, ui);
                         });

--- a/src/gui/settings.rs
+++ b/src/gui/settings.rs
@@ -197,7 +197,8 @@ fn render_deploy_config(config: &mut DeployConfig, platform: Platform, ui: &mut 
     ui.label(loc.get("Settings_Platform_Deploy"));
     let mut changed = false;
     ui.group(|ui| {
-        ui.allocate_space([ui.available_width(), -8.0].into());
+        let width = ui.available_width().max(0.0);
+        ui.allocate_space([width, 0.0].into());
         let mut name = loc.get("Settings_Platform_Deploy_Method");
         let mut description = loc.get("Settings_Platform_Deploy_Method_Desc");
         render_setting(
@@ -345,7 +346,8 @@ fn render_platform_config(
     ui.add_space(8.0);
     ui.label(loc.get("Settings_Platform_Dump"));
     ui.group(|ui| {
-        ui.allocate_space([ui.available_width(), -8.0].into());
+        let width = ui.available_width().max(0.0);
+        ui.allocate_space([width, 0.0].into());
         if platform == Platform::WiiU {
             name = loc.get("Settings_Platform_Dump_Type");
             description = loc.get("Settings_Platform_Dump_Type_Desc");

--- a/src/gui/tabs.rs
+++ b/src/gui/tabs.rs
@@ -76,7 +76,8 @@ impl TabViewer for super::App {
                                 visuals::slate_grid(ui);
                             }
                             self.render_modlist(ui);
-                            ui.allocate_space(ui.available_size());
+                            let available = ui.available_size();
+                            ui.allocate_space([available.x.max(0.0), available.y.max(0.0)].into());
                             self.render_pending(ui);
                         });
                 }


### PR DESCRIPTION
Validate widget sizes to ensure they are finite and non-negative before passing to egui. Fixes panics when ui.available_size() returns invalid values in certain layout contexts.